### PR TITLE
Align postgres engine naming

### DIFF
--- a/apis/azure/composition.yaml
+++ b/apis/azure/composition.yaml
@@ -49,11 +49,6 @@ spec:
           toFieldPath: spec.parameters.networkRef.id
         - fromFieldPath: spec.parameters.engine
           toFieldPath: spec.compositionSelector.matchLabels[dbengine]
-          transforms:  # NOTE(ytsarev): to be removed when azure-database consolidate on 'postgres' selector in next release
-            - type: map
-              map:
-                mariadb: mariadb
-                postgres: postgresql
       connectionDetails:
         - type: FromConnectionSecretKey
           name: host

--- a/crossplane.yaml
+++ b/crossplane.yaml
@@ -6,6 +6,13 @@ metadata:
     meta.crossplane.io/maintainer: Upbound <support@upbound.io>
     meta.crossplane.io/source: github.com/upbound/configuration-dbaas
     meta.crossplane.io/license: Apache-2.0
+    meta.crossplane.io/description: |
+      The configuration-dbaas configuration provides abstraction over multicloud
+      database instance management.
+    meta.crossplane.io/readme: |
+      The configuration-dbaas bundles the single API that allows unified multicloud
+      provisioning of fully managed database instances.
+      Deploy most popular database services using the same consistent Claim spec.
 
 spec:
   crossplane:
@@ -14,4 +21,4 @@ spec:
     - configuration: xpkg.upbound.io/upbound/configuration-aws-database
       version: ">=v0.1.0"
     - configuration: xpkg.upbound.io/upbound/configuration-azure-database
-      version: ">=v0.1.0"
+      version: ">=v0.2.0"


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Employ https://github.com/upbound/configuration-azure-database/releases/tag/v0.2.0 to align on the consisten `postgres` engine naming
* Remove the associated transform in Azure Composition
* Add package meta in preparation to release

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

uptest below
