### PR TITLE
Add Cloud, Engine, Version printer column.  Expose version for Azure

### DIFF
--- a/apis/azure/composition.yaml
+++ b/apis/azure/composition.yaml
@@ -77,6 +77,9 @@ spec:
               - type: FromCompositeFieldPath
                 fromFieldPath: spec.parameters.engine
                 toFieldPath: spec.compositionSelector.matchLabels[dbengine]
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.engineVersion
+                toFieldPath: spec.parameters.version
 
           - name: xnetwork
             base:

--- a/apis/definition.yaml
+++ b/apis/definition.yaml
@@ -19,6 +19,19 @@ spec:
     - name: v1alpha1
       served: true
       referenceable: true
+      additionalPrinterColumns:
+        - name: Cloud
+          type: string
+          description: Cloud Environment
+          jsonPath: .spec.compositionSelector.matchLabels.provider
+        - name: Engine
+          type: string
+          description: Database Engine
+          jsonPath: .spec.parameters.engine
+        - name: Version
+          type: string
+          description: Database Engine Verion
+          jsonPath: .spec.parameters.engineVersion
       schema:
         openAPIV3Schema:
           type: object

--- a/examples/mariadb-azure-claim.yaml
+++ b/examples/mariadb-azure-claim.yaml
@@ -10,6 +10,7 @@ spec:
   parameters:
     region: westus
     engine: mariadb
+    engineVersion: "10.3"
     storageGB: 5
     passwordSecretRef:
       namespace: default

--- a/examples/postgres-azure-claim.yaml
+++ b/examples/postgres-azure-claim.yaml
@@ -10,6 +10,7 @@ spec:
   parameters:
     region: westus
     engine: postgres
+    engineVersion: "11"
     storageGB: 5
     passwordSecretRef:
       namespace: default


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

* Add Cloud, Engine, Version printer column for enhanced UX

* Expose version for Azure



I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
--- PASS: kuttl (1305.62s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/case (1305.12s)
PASS
16:49:03 [ OK ] running automated tests
```

```
k get claim
NAME                                                                CLOUD   ENGINE     VERSION   SYNCED   READY   CONNECTION-SECRET                      AGE
sqlinstance.dbaas.upbound.io/configuration-dbaas-aws-mariadb        aws     mariadb    10.11     True     True    configuration-dbaas-aws-mariadb        17m
sqlinstance.dbaas.upbound.io/configuration-dbaas-aws-postgresql     aws     postgres   15.3      True     True    configuration-dbaas-aws-postgresql     17m
sqlinstance.dbaas.upbound.io/configuration-dbaas-azure-mariadb      azure   mariadb    10.3      True     True    configuration-dbaas-azure-mariadb      17m
sqlinstance.dbaas.upbound.io/configuration-dbaas-azure-postgresql   azure   postgres   11        True     True    configuration-dbaas-azure-postgresql   17m
sqlinstance.dbaas.upbound.io/configuration-dbaas-gcp-mysql          gcp     mysql      8_0       True     True    configuration-dbaas-gcp-mysql          17m
sqlinstance.dbaas.upbound.io/configuration-dbaas-gcp-postgresql     gcp     postgres   15        True     True    configuration-dbaas-gcp-postgresql
```

Plus uptest below